### PR TITLE
feat: add Discord event handling for assignment creation, update, delete

### DIFF
--- a/interactions/assignmentActions.go
+++ b/interactions/assignmentActions.go
@@ -200,7 +200,7 @@ func (handler *InteractionHandler) DeleteAssignment(bot *discordgo.Session, inte
 		return
 	}
 
-	events, err := bot.GuildScheduledEvents(assignmentID, false)
+	events, err := bot.GuildScheduledEvents(interactionCreate.GuildID, false)
 	if err != nil {
 		slog.Error(stacktrace.Propagate(err, "error getting guild events").Error())
 	}

--- a/interactions/assignmentActions.go
+++ b/interactions/assignmentActions.go
@@ -50,6 +50,7 @@ func (handler *InteractionHandler) UpdateAssignment(bot *discordgo.Session, inte
 		}
 		return
 	}
+
 	err = bot.InteractionRespond(interactionCreate.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseModal,
 		Data: &discordgo.InteractionResponseData{
@@ -144,6 +145,27 @@ func (handler *InteractionHandler) UpdateAssignmentSubmit(bot *discordgo.Session
 		return
 	}
 
+	events, err := bot.GuildScheduledEvents(updatedAssignment.CourseID, false)
+	if err != nil {
+		slog.Error(stacktrace.Propagate(err, "error getting guild events").Error())
+	}
+	for _, event := range events {
+		if event.Description == updatedAssignment.ID {
+			startTime := updatedAssignment.Due.Add(-1 * time.Hour)
+			go bot.GuildScheduledEventEdit(updatedAssignment.CourseID, event.ID, &discordgo.GuildScheduledEventParams{
+				Name:               updatedAssignment.Name,
+				Description:        updatedAssignment.ID,
+				ScheduledStartTime: &startTime,
+				ScheduledEndTime:   &updatedAssignment.Due,
+				PrivacyLevel:       discordgo.GuildScheduledEventPrivacyLevelGuildOnly,
+				EntityType:         discordgo.GuildScheduledEventEntityTypeExternal,
+				EntityMetadata: &discordgo.GuildScheduledEventEntityMetadata{
+					Location: updatedAssignment.URL,
+				},
+			}) //nolint:errcheck
+		}
+	}
+
 	_, err = bot.FollowupMessageCreate(interactionCreate.Interaction, false, &discordgo.WebhookParams{
 		Content:    "assignment updated!",
 		Embeds:     []*discordgo.MessageEmbed{views.AssignmentView(interactionCreate.Member, updatedAssignment)},
@@ -175,6 +197,16 @@ func (handler *InteractionHandler) DeleteAssignment(bot *discordgo.Session, inte
 			slog.Error(stacktrace.Propagate(err, "error responding to interaction").Error())
 		}
 		return
+	}
+
+	events, err := bot.GuildScheduledEvents(assignmentID, false)
+	if err != nil {
+		slog.Error(stacktrace.Propagate(err, "error getting guild events").Error())
+	}
+	for _, event := range events {
+		if event.Description == assignmentID {
+			go bot.GuildScheduledEventDelete(interactionCreate.GuildID, event.ID) //nolint:errcheck
+		}
 	}
 
 	err = bot.InteractionRespond(interactionCreate.Interaction, &discordgo.InteractionResponse{

--- a/interactions/assignmentActions.go
+++ b/interactions/assignmentActions.go
@@ -152,6 +152,7 @@ func (handler *InteractionHandler) UpdateAssignmentSubmit(bot *discordgo.Session
 	for _, event := range events {
 		if event.Description == updatedAssignment.ID {
 			startTime := updatedAssignment.Due.Add(-1 * time.Hour)
+			//nolint:errcheck
 			go bot.GuildScheduledEventEdit(updatedAssignment.CourseID, event.ID, &discordgo.GuildScheduledEventParams{
 				Name:               updatedAssignment.Name,
 				Description:        updatedAssignment.ID,
@@ -162,7 +163,7 @@ func (handler *InteractionHandler) UpdateAssignmentSubmit(bot *discordgo.Session
 				EntityMetadata: &discordgo.GuildScheduledEventEntityMetadata{
 					Location: updatedAssignment.URL,
 				},
-			}) //nolint:errcheck
+			})
 		}
 	}
 
@@ -205,7 +206,8 @@ func (handler *InteractionHandler) DeleteAssignment(bot *discordgo.Session, inte
 	}
 	for _, event := range events {
 		if event.Description == assignmentID {
-			go bot.GuildScheduledEventDelete(interactionCreate.GuildID, event.ID) //nolint:errcheck
+			//nolint:errcheck
+			go bot.GuildScheduledEventDelete(interactionCreate.GuildID, event.ID)
 		}
 	}
 

--- a/interactions/assignmentListActions.go
+++ b/interactions/assignmentListActions.go
@@ -118,6 +118,7 @@ func (handler *InteractionHandler) AddAssignmentSubmit(bot *discordgo.Session, i
 	}
 
 	startTime := assignment.Due.Add(-1 * time.Hour)
+	//nolint:errcheck
 	go bot.GuildScheduledEventCreate(assignment.CourseID, &discordgo.GuildScheduledEventParams{
 		Name:               assignment.Name,
 		Description:        assignment.ID,
@@ -128,7 +129,7 @@ func (handler *InteractionHandler) AddAssignmentSubmit(bot *discordgo.Session, i
 		EntityMetadata: &discordgo.GuildScheduledEventEntityMetadata{
 			Location: assignment.URL,
 		},
-	}) //nolint:errcheck
+	})
 
 	_, err = bot.FollowupMessageCreate(interactionCreate.Interaction, false, &discordgo.WebhookParams{
 		Content:    "assignment created!",

--- a/interactions/assignmentListActions.go
+++ b/interactions/assignmentListActions.go
@@ -117,6 +117,19 @@ func (handler *InteractionHandler) AddAssignmentSubmit(bot *discordgo.Session, i
 		return
 	}
 
+	startTime := assignment.Due.Add(-1 * time.Hour)
+	go bot.GuildScheduledEventCreate(assignment.CourseID, &discordgo.GuildScheduledEventParams{
+		Name:               assignment.Name,
+		Description:        assignment.ID,
+		ScheduledStartTime: &startTime,
+		ScheduledEndTime:   &assignment.Due,
+		PrivacyLevel:       discordgo.GuildScheduledEventPrivacyLevelGuildOnly,
+		EntityType:         discordgo.GuildScheduledEventEntityTypeExternal,
+		EntityMetadata: &discordgo.GuildScheduledEventEntityMetadata{
+			Location: assignment.URL,
+		},
+	}) //nolint:errcheck
+
 	_, err = bot.FollowupMessageCreate(interactionCreate.Interaction, false, &discordgo.WebhookParams{
 		Content:    "assignment created!",
 		Embeds:     []*discordgo.MessageEmbed{views.AssignmentView(interactionCreate.Member, createdAssignment)},

--- a/interactions/assignmentListActions.go
+++ b/interactions/assignmentListActions.go
@@ -117,17 +117,17 @@ func (handler *InteractionHandler) AddAssignmentSubmit(bot *discordgo.Session, i
 		return
 	}
 
-	startTime := assignment.Due.Add(-1 * time.Hour)
+	startTime := createdAssignment.Due.Add(-1 * time.Hour)
 	//nolint:errcheck
-	go bot.GuildScheduledEventCreate(assignment.CourseID, &discordgo.GuildScheduledEventParams{
-		Name:               assignment.Name,
-		Description:        assignment.ID,
+	go bot.GuildScheduledEventCreate(createdAssignment.CourseID, &discordgo.GuildScheduledEventParams{
+		Name:               createdAssignment.Name,
+		Description:        createdAssignment.ID,
 		ScheduledStartTime: &startTime,
-		ScheduledEndTime:   &assignment.Due,
+		ScheduledEndTime:   &createdAssignment.Due,
 		PrivacyLevel:       discordgo.GuildScheduledEventPrivacyLevelGuildOnly,
 		EntityType:         discordgo.GuildScheduledEventEntityTypeExternal,
 		EntityMetadata: &discordgo.GuildScheduledEventEntityMetadata{
-			Location: assignment.URL,
+			Location: createdAssignment.URL,
 		},
 	})
 


### PR DESCRIPTION
Closes #2 

During AddAssignmentSubmit, create Discord Guild Scheduled Event for the assignment.
During UpdateAssignmentSubmit, edit Discord Guild Scheduled Event for the assignment.
During DeleteAssignmentSubmit, delete Discord Guild scheduled event for the assignment.