### PR TITLE
implement /hakase rps command with random GIFs

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/2d6327017519d23b96af35865dc997fcb544fb40/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/src/main/kotlin/dev/dragonejt/hakase/events/ReadyHandler.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/events/ReadyHandler.kt
@@ -1,37 +1,24 @@
 package dev.dragonejt.hakase.events
 
-import dev.dragonejt.hakase.telemetry.LogBase
 import dev.minn.jda.ktx.events.CoroutineEventListener
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
-import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.events.GenericEvent
 import net.dv8tion.jda.api.events.session.ReadyEvent
 import org.springframework.stereotype.Service
 
 @Service
-class ReadyHandler(private val tracer: Tracer) : CoroutineEventListener, LogBase() {
+class ReadyHandler(private val tracer: Tracer) : CoroutineEventListener {
+    private val log = KotlinLogging.logger {}
 
     override suspend fun onEvent(event: GenericEvent) {
         if (event !is ReadyEvent) return
 
-        val span =
-            tracer
-                .spanBuilder("events.${this.javaClass.simpleName}")
-                .setSpanKind(SpanKind.SERVER)
-                .startSpan()
+        val span = tracer.spanBuilder("events.ready").setSpanKind(SpanKind.SERVER).startSpan()
         val scope = span.makeCurrent()
 
-        log.atInfo {
-            message = "Logged in as ${event.jda.selfUser.name}!"
-            payload = mapOf("bot_user" to event.jda.selfUser.name)
-        }
-
-        event.jda.presence.activity =
-            Activity.of(
-                Activity.ActivityType.CUSTOM_STATUS,
-                "hakase.dragonejt.dev | in ${event.jda.guilds.size} courses",
-            )
+        log.info { "Logged in as ${event.jda.selfUser.name}!" }
 
         scope.close()
         span.end()

--- a/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Service
 class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScope) :
     ApplicationCommand, CoroutineEventListener, LogBase() {
 
-    @Value("\${discord-bot.rps-gifs}") private lateinit var rpsGifs: List<String>
+    @Value("\${discord-bot.rps-gifs}")
+    private lateinit var rpsGifs: List<String>
 
     override fun command() =
         Commands.slash("hakase", "hakase settings")

--- a/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
@@ -18,8 +18,7 @@ import org.springframework.stereotype.Service
 class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScope) :
     ApplicationCommand, CoroutineEventListener, LogBase() {
 
-    @Value("\${discord-bot.rps-gifs}")
-    private lateinit var rpsGifs: List<String>
+    @Value("\${discord-bot.rps-gifs}") private lateinit var rpsGifs: List<String>
 
     override fun command() =
         Commands.slash("hakase", "hakase settings")

--- a/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service
 class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScope) :
     ApplicationCommand, CoroutineEventListener, LogBase() {
 
-    @Value("\${discord-bot.rps-gifs}") private lateinit var rpsGifs: List<String>
+    @Value("\${discord.rps-gifs}") private lateinit var rpsGifs: List<String>
 
     override fun command() =
         Commands.slash("hakase", "hakase settings")
@@ -26,7 +26,7 @@ class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScop
                 OptionData(OptionType.STRING, "cmd", "subcommand to run")
                     .addChoice(
                         "config",
-                        "hakase configuration",
+                        "config",
                     )
                     .addChoice("rps", "rps")
             )
@@ -48,15 +48,19 @@ class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScop
 
         val cmdOption = event.getOption("cmd")?.asString
         when (cmdOption) {
-            "rps" -> event.reply(rps()).await()
-            else -> event.reply("hakase pong!").await()
+            "rps" -> rps(event)
+            else -> default(event)
         }
 
         scope.close()
         span.end()
     }
 
-    private fun rps(): String {
-        return rpsGifs.random()
+    private suspend fun rps(event: SlashCommandInteractionEvent) {
+        event.reply(rpsGifs.random()).await()
+    }
+
+    private suspend fun default(event: SlashCommandInteractionEvent) {
+        event.reply("hakase pong!").await()
     }
 }

--- a/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
@@ -11,20 +11,14 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
 class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScope) :
     ApplicationCommand, CoroutineEventListener, LogBase() {
 
-    companion object {
-        private val RPS_GIFS =
-            listOf(
-                "https://klipy.com/gifs/rock-everythingeverywhereallatonce-1",
-                "https://klipy.com/gifs/paper-plane-flying-original",
-                "https://klipy.com/gifs/the-amazing-world-of-gumball-gumball-and-darwin",
-            )
-    }
+    @Value("\${discord-bot.rps-gifs}") private lateinit var rpsGifs: List<String>
 
     override fun command() =
         Commands.slash("hakase", "hakase settings")
@@ -34,7 +28,7 @@ class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScop
                         "config",
                         "hakase configuration",
                     )
-                    .addChoice("rps", "rock-paper-scissors")
+                    .addChoice("rps", "rps")
             )
 
     override suspend fun onEvent(event: GenericEvent) {
@@ -53,13 +47,16 @@ class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScop
         }
 
         val cmdOption = event.getOption("cmd")?.asString
-        if (cmdOption == "rock-paper-scissors") {
-            event.reply(RPS_GIFS.random()).await()
-        } else {
-            event.reply("hakase pong!").await()
+        when (cmdOption) {
+            "rps" -> event.reply(rps()).await()
+            else -> event.reply("hakase pong!").await()
         }
 
         scope.close()
         span.end()
+    }
+
+    private fun rps(): String {
+        return rpsGifs.random()
     }
 }

--- a/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/interactions/HakaseCommand.kt
@@ -17,6 +17,15 @@ import org.springframework.stereotype.Service
 class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScope) :
     ApplicationCommand, CoroutineEventListener, LogBase() {
 
+    companion object {
+        private val RPS_GIFS =
+            listOf(
+                "https://klipy.com/gifs/rock-everythingeverywhereallatonce-1",
+                "https://klipy.com/gifs/paper-plane-flying-original",
+                "https://klipy.com/gifs/the-amazing-world-of-gumball-gumball-and-darwin",
+            )
+    }
+
     override fun command() =
         Commands.slash("hakase", "hakase settings")
             .addOptions(
@@ -43,7 +52,12 @@ class HakaseCommand(private val tracer: Tracer, private val scope: CoroutineScop
             payload = mapOf("username" to event.user.effectiveName)
         }
 
-        event.reply("hakase pong!").await()
+        val cmdOption = event.getOption("cmd")?.asString
+        if (cmdOption == "rock-paper-scissors") {
+            event.reply(RPS_GIFS.random()).await()
+        } else {
+            event.reply("hakase pong!").await()
+        }
 
         scope.close()
         span.end()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,3 +10,7 @@ ontology:
   client-id: 33976368fd8b43e534fd9e4b0a51c4c0
   token: ${FOUNDRY_AUTH_TOKEN}
 
+discord-bot:
+  rps-gifs: https://klipy.com/gifs/rock-everythingeverywhereallatonce-1,
+            https://klipy.com/gifs/paper-plane-flying-original,
+            https://klipy.com/gifs/the-amazing-world-of-gumball-gumball-and-darwin

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,13 +4,12 @@ spring:
 
 discord:
   token: ${DISCORD_BOT_TOKEN}
+  rps-gifs: https://klipy.com/gifs/rock-everythingeverywhereallatonce-1,
+            https://klipy.com/gifs/paper-plane-flying-original,
+            https://klipy.com/gifs/the-amazing-world-of-gumball-gumball-and-darwin
 
 ontology:
   url: https://dragonejt.usw-16.palantirfoundry.com
   client-id: 33976368fd8b43e534fd9e4b0a51c4c0
   token: ${FOUNDRY_AUTH_TOKEN}
-
-discord-bot:
-  rps-gifs: https://klipy.com/gifs/rock-everythingeverywhereallatonce-1,
-            https://klipy.com/gifs/paper-plane-flying-original,
-            https://klipy.com/gifs/the-amazing-world-of-gumball-gumball-and-darwin
+  


### PR DESCRIPTION
- Added a static list of Rock Paper Scissors GIFs to the "HakaseCommand" companion object.
- Implemented routing in "onEvent" to capture when the "cmd" option equals `"rock-paper-scissors"`.
- When triggered, the bot now responds to the interaction with a random GIF from the predefined list instead of the default "hakase pong!".