### PR TITLE
Implemented CourseRepository and GuildEventHandlers for bot lifecycle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.data:spring-data-commons")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("net.dv8tion:JDA:6.4.2")
     implementation("club.minnced:jda-ktx:0.14.2")
@@ -48,6 +49,7 @@ dependencies {
         exclude(group = "org.slf4j", module = "slf4j-log4j12")
         exclude(group = "com.palantir.sls.logging", module = "sls-logging-log4j-slf4j")
     }
+    
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/dev/dragonejt/hakase/clients/OntologyConfiguration.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/clients/OntologyConfiguration.kt
@@ -1,6 +1,6 @@
 package dev.dragonejt.hakase.clients
 
-import com.palantir.osdk.api.auth.ConfidentialClientAuth
+import com.palantir.osdk.api.UserTokenAuth
 import com.palantir.osdk.internal.api.FoundryConnectionConfig
 import dev.dragonejt.hakase.telemetry.LogBase
 import dev.dragonejt.hakase_sdk.FoundryClient
@@ -20,15 +20,10 @@ class OntologyConfiguration : LogBase() {
     @Bean
     fun ontology(props: OntologyProperties): Ontology {
         log.atDebug {
-            message =
-                "Building Palantir Ontology SDK Client with URL: ${props.url} and client ID: ${props.clientID}"
-            payload = mapOf("foundry_uri" to props.url, "foundry_client_id" to props.clientID)
+            message = "Building Palantir Ontology SDK Client with URL: ${props.url} and User Token"
+            payload = mapOf("foundry_uri" to props.url)
         }
-        val auth =
-            ConfidentialClientAuth.builder()
-                .clientId(props.clientID)
-                .clientSecret(props.token)
-                .build()
+        val auth = UserTokenAuth.builder().token(props.token).build()
         val connection = FoundryConnectionConfig.builder().foundryUri(props.url).build()
 
         return FoundryClient.builder().auth(auth).connectionConfig(connection).build().ontology()

--- a/src/main/kotlin/dev/dragonejt/hakase/datamodels/Course.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/datamodels/Course.kt
@@ -1,0 +1,3 @@
+package dev.dragonejt.hakase.datamodels
+
+data class Course(val courseId: String, val notifyChannel: String, val notifyGroup: String)

--- a/src/main/kotlin/dev/dragonejt/hakase/events/GuildJoinHandler.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/events/GuildJoinHandler.kt
@@ -1,5 +1,7 @@
 package dev.dragonejt.hakase.events
 
+import dev.dragonejt.hakase.datamodels.Course
+import dev.dragonejt.hakase.osdk.CourseRepository
 import dev.dragonejt.hakase.telemetry.LogBase
 import dev.minn.jda.ktx.events.CoroutineEventListener
 import io.opentelemetry.api.trace.SpanKind
@@ -10,7 +12,8 @@ import net.dv8tion.jda.api.events.guild.GuildJoinEvent
 import org.springframework.stereotype.Service
 
 @Service
-class GuildJoinHandler(private val tracer: Tracer) : CoroutineEventListener, LogBase() {
+class GuildJoinHandler(private val tracer: Tracer, private val courses: CourseRepository) :
+    CoroutineEventListener, LogBase() {
 
     override suspend fun onEvent(event: GenericEvent) {
         if (event !is GuildJoinEvent) return
@@ -26,6 +29,9 @@ class GuildJoinHandler(private val tracer: Tracer) : CoroutineEventListener, Log
             message = "Bot joined guild ${event.guild.name} (${event.guild.id})"
             payload = mapOf("guild_name" to event.guild.name, "guild_id" to event.guild.id)
         }
+
+        val course = Course(event.guild.id, event.guild.defaultChannel!!.id, "")
+        courses.save(course)
 
         event.jda.presence.activity =
             Activity.of(

--- a/src/main/kotlin/dev/dragonejt/hakase/events/GuildLeaveHandler.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/events/GuildLeaveHandler.kt
@@ -1,5 +1,6 @@
 package dev.dragonejt.hakase.events
 
+import dev.dragonejt.hakase.osdk.CourseRepository
 import dev.dragonejt.hakase.telemetry.LogBase
 import dev.minn.jda.ktx.events.CoroutineEventListener
 import io.opentelemetry.api.trace.SpanKind
@@ -10,7 +11,8 @@ import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
 import org.springframework.stereotype.Service
 
 @Service
-class GuildLeaveHandler(private val tracer: Tracer) : CoroutineEventListener, LogBase() {
+class GuildLeaveHandler(private val tracer: Tracer, private val courses: CourseRepository) :
+    CoroutineEventListener, LogBase() {
     override suspend fun onEvent(event: GenericEvent) {
         if (event !is GuildLeaveEvent) return
 
@@ -25,7 +27,7 @@ class GuildLeaveHandler(private val tracer: Tracer) : CoroutineEventListener, Lo
             message = "Bot left guild ${event.guild.name} (${event.guild.id})"
             payload = mapOf("guild_name" to event.guild.name, "guild_id" to event.guild.id)
         }
-
+        courses.deleteById(event.guild.id)
         event.jda.presence.activity =
             Activity.of(
                 Activity.ActivityType.CUSTOM_STATUS,

--- a/src/main/kotlin/dev/dragonejt/hakase/interactions/AssignmentCommand.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/interactions/AssignmentCommand.kt
@@ -1,0 +1,35 @@
+import dev.dragonejt.hakase.interactions.ApplicationCommand
+import dev.dragonejt.hakase.telemetry.LogBase
+import dev.minn.jda.ktx.events.CoroutineEventListener
+import net.dv8tion.jda.api.events.GenericEvent
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+
+class AssignmentCommand : ApplicationCommand, CoroutineEventListener, LogBase() {
+    override fun command() =
+        Commands.slash("assignments", "List all Assigments")
+            .addOption(OptionType.STRING, "Assignment ID", "ID of the assignment to view")
+
+    override suspend fun onEvent(event: GenericEvent) {
+        if (event !is SlashCommandInteractionEvent || event.fullCommandName != command().name)
+            return
+        event.deferReply().queue()
+
+        val assignmentId = event.getOption("Assignment ID")?.asString
+        when (assignmentId) {
+            null -> listAll(event)
+            else -> viewAssignment(event, assignmentId)
+        }
+    }
+
+    @Suppress("UnusedPrivateMember", "UNUSED_PARAMETER")
+    private suspend fun listAll(event: SlashCommandInteractionEvent) {
+        // List all functions
+    }
+
+    @Suppress("UnusedPrivateMember", "UNUSED_PARAMETER")
+    private suspend fun viewAssignment(event: SlashCommandInteractionEvent, assignmentId: String) {
+        // Implement viewing a single assignment
+    }
+}

--- a/src/main/kotlin/dev/dragonejt/hakase/osdk/CourseRepository.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/osdk/CourseRepository.kt
@@ -1,0 +1,121 @@
+package dev.dragonejt.hakase.osdk
+
+import com.palantir.osdk.api.actions.ValidationResult
+import dev.dragonejt.hakase.datamodels.Course
+import dev.dragonejt.hakase_sdk.Ontology5a5029d53a2342fdA36a2cf9e72e73b9 as Ontology
+import dev.dragonejt.hakase_sdk.actions.CreateCourseActionRequest
+import dev.dragonejt.hakase_sdk.actions.CreateCourseActionResponse
+import dev.dragonejt.hakase_sdk.actions.DeleteCourseActionRequest
+import dev.dragonejt.hakase_sdk.actions.DeleteCourseActionResponse
+import dev.dragonejt.hakase_sdk.actions.EditCourseActionRequest
+import dev.dragonejt.hakase_sdk.actions.EditCourseActionResponse
+import java.util.Optional
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Service
+
+@Service
+@Suppress("TooManyFunctions")
+class CourseRepository(private val ontology: Ontology) : CrudRepository<Course, String> {
+    override fun <S : Course> save(entity: S): S {
+        if (findById(entity.courseId).isPresent) {
+            val response: EditCourseActionResponse =
+                ontology
+                    .actions()
+                    .editCourse()
+                    .apply(
+                        EditCourseActionRequest.builder()
+                            .course(entity.courseId)
+                            .notifyChannel(entity.notifyChannel)
+                            .notifyGroup(entity.notifyGroup)
+                            .build()
+                    )
+            if (response.validationResult.validation.result == ValidationResult.VALID) {
+                if (response.actionEdits.isPresent) {
+                    return entity
+                }
+            }
+        } else {
+            val response: CreateCourseActionResponse =
+                ontology
+                    .actions()
+                    .createCourse()
+                    .apply(
+                        CreateCourseActionRequest.builder()
+                            .notifyChannel(entity.notifyChannel)
+                            .notifyGroup(entity.notifyGroup)
+                            .courseId(entity.courseId)
+                            .build()
+                    )
+            if (response.validationResult.validation.result == ValidationResult.VALID) {
+                if (response.actionEdits.isPresent) {
+                    return entity
+                }
+            }
+        }
+
+        throw IllegalArgumentException("Failed to save course")
+    }
+
+    override fun <S : Course> saveAll(entities: Iterable<S>): Iterable<S> {
+        throw UnsupportedOperationException("Not implemented")
+    }
+
+    override fun findById(id: String): Optional<Course> {
+        val osdkCourse = ontology.objects().Course().fetch(id)
+        return osdkCourse.map { course ->
+            Course(
+                course.courseId().get(),
+                course.notifyChannel().get(),
+                course.notifyGroup().get(),
+            )
+        }
+    }
+
+    override fun existsById(id: String): Boolean {
+        throw UnsupportedOperationException("Not implemented")
+    }
+
+    override fun findAll(): Iterable<Course> {
+        throw UnsupportedOperationException("Not implemented")
+    }
+
+    override fun findAllById(ids: Iterable<String>): Iterable<Course> {
+        throw UnsupportedOperationException("Not implemented")
+    }
+
+    override fun count(): Long {
+        throw UnsupportedOperationException("Not implemented")
+    }
+
+    override fun deleteById(id: String): Unit {
+        val response: DeleteCourseActionResponse =
+            ontology
+                .actions()
+                .deleteCourse()
+                .apply(DeleteCourseActionRequest.builder().course(id).build())
+
+        if (response.validationResult.validation.result == ValidationResult.VALID) {
+            if (response.actionEdits.isPresent) {
+                return
+            }
+        }
+
+        throw IllegalArgumentException("Failed to delete course")
+    }
+
+    override fun delete(entity: Course): Unit {
+        deleteById(entity.courseId)
+    }
+
+    override fun deleteAllById(ids: Iterable<String>): Unit {
+        throw UnsupportedOperationException("Not implemented")
+    }
+
+    override fun deleteAll(entities: Iterable<out Course>): Unit {
+        throw UnsupportedOperationException("Not implemented")
+    }
+
+    override fun deleteAll(): Unit {
+        throw UnsupportedOperationException("Not implemented")
+    }
+}

--- a/src/main/kotlin/dev/dragonejt/hakase/osdk/CourseRepository.kt
+++ b/src/main/kotlin/dev/dragonejt/hakase/osdk/CourseRepository.kt
@@ -11,9 +11,9 @@ import dev.dragonejt.hakase_sdk.actions.EditCourseActionRequest
 import dev.dragonejt.hakase_sdk.actions.EditCourseActionResponse
 import java.util.Optional
 import org.springframework.data.repository.CrudRepository
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Repository
 
-@Service
+@Repository
 @Suppress("TooManyFunctions")
 class CourseRepository(private val ontology: Ontology) : CrudRepository<Course, String> {
     override fun <S : Course> save(entity: S): S {

--- a/src/test/kotlin/dev/dragonejt/hakase/osdk/CourseRepositoryTests.kt
+++ b/src/test/kotlin/dev/dragonejt/hakase/osdk/CourseRepositoryTests.kt
@@ -1,0 +1,194 @@
+package dev.dragonejt.hakase.osdk
+
+import dev.dragonejt.hakase.datamodels.Course
+import dev.dragonejt.hakase_sdk.Ontology5a5029d53a2342fdA36a2cf9e72e73b9 as Ontology
+import dev.dragonejt.hakase_sdk.Ontology5a5029d53a2342fdA36a2cf9e72e73b9Actions as OntologyActions
+import dev.dragonejt.hakase_sdk.Ontology5a5029d53a2342fdA36a2cf9e72e73b9BaseObjectSets as OntologyBaseObjectSets
+import dev.dragonejt.hakase_sdk.objectsets.CourseObjectSet
+import java.util.Optional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class CourseRepositoryTests {
+
+    @Mock private lateinit var ontology: Ontology
+    private lateinit var underTest: CourseRepository
+
+    @BeforeEach
+    fun setUp() {
+        underTest = CourseRepository(ontology)
+    }
+
+    @Test
+    @DisplayName("CourseRepository saves new course")
+    fun testNewCourseSave() {
+        val course = Course("test_course_id", "channel_id", "group_id")
+
+        val mockObjects = mock<OntologyBaseObjectSets>()
+        whenever { ontology.objects() }.thenReturn(mockObjects)
+
+        val mockCourse = mock<CourseObjectSet>()
+        whenever { mockObjects.Course() }.thenReturn(mockCourse)
+        whenever { mockCourse.fetch(course.courseId) }.thenReturn(Optional.empty())
+
+        val mockActions = mock<OntologyActions>()
+        whenever { ontology.actions() }.thenReturn(mockActions)
+
+        val mockCreateCourse = mock<dev.dragonejt.hakase_sdk.actions.CreateCourseAction>()
+        whenever { mockActions.createCourse() }.thenReturn(mockCreateCourse)
+
+        val mockResponse =
+            org.mockito.Mockito.mock(
+                dev.dragonejt.hakase_sdk.actions.CreateCourseActionResponse::class.java,
+                org.mockito.Mockito.RETURNS_DEEP_STUBS,
+            )
+        whenever {
+                mockCreateCourse.apply(
+                    any<dev.dragonejt.hakase_sdk.actions.CreateCourseActionRequest>()
+                )
+            }
+            .thenReturn(mockResponse)
+
+        whenever { mockResponse.validationResult.validation.result }
+            .thenReturn(com.palantir.osdk.api.actions.ValidationResult.VALID)
+        val mockEdits = mock<dev.dragonejt.hakase_sdk.actions.CreateCourseActionEditsResult>()
+        whenever { mockResponse.actionEdits }.thenReturn(Optional.of(mockEdits))
+
+        val result = underTest.save(course)
+
+        assertAll(
+            { verify(mockCourse).fetch(course.courseId) },
+            {
+                verify(mockCreateCourse)
+                    .apply(any<dev.dragonejt.hakase_sdk.actions.CreateCourseActionRequest>())
+            },
+            { assertThat(result).isEqualTo(course) },
+        )
+    }
+
+    @Test
+    @DisplayName("CourseRepository updates existing course")
+    fun testExistingCourseSave() {
+        val course = Course("test_course_id", "channel_id", "group_id")
+
+        val mockObjects = mock<OntologyBaseObjectSets>()
+        whenever { ontology.objects() }.thenReturn(mockObjects)
+
+        val mockCourse = mock<CourseObjectSet>()
+        whenever { mockObjects.Course() }.thenReturn(mockCourse)
+
+        val mockOsdkCourse = mock<dev.dragonejt.hakase_sdk.objects.Course>()
+        whenever { mockOsdkCourse.courseId() }.thenReturn(Optional.of(course.courseId))
+        whenever { mockOsdkCourse.notifyChannel() }.thenReturn(Optional.of("channel_id"))
+        whenever { mockOsdkCourse.notifyGroup() }.thenReturn(Optional.of("group_id"))
+        whenever { mockCourse.fetch(course.courseId) }.thenReturn(Optional.of(mockOsdkCourse))
+
+        val mockActions = mock<OntologyActions>()
+        whenever { ontology.actions() }.thenReturn(mockActions)
+
+        val mockEditCourse = mock<dev.dragonejt.hakase_sdk.actions.EditCourseAction>()
+        whenever { mockActions.editCourse() }.thenReturn(mockEditCourse)
+
+        val mockResponse =
+            org.mockito.Mockito.mock(
+                dev.dragonejt.hakase_sdk.actions.EditCourseActionResponse::class.java,
+                org.mockito.Mockito.RETURNS_DEEP_STUBS,
+            )
+        whenever {
+                mockEditCourse.apply(
+                    any<dev.dragonejt.hakase_sdk.actions.EditCourseActionRequest>()
+                )
+            }
+            .thenReturn(mockResponse)
+
+        whenever { mockResponse.validationResult.validation.result }
+            .thenReturn(com.palantir.osdk.api.actions.ValidationResult.VALID)
+        val mockEdits = mock<dev.dragonejt.hakase_sdk.actions.EditCourseActionEditsResult>()
+        whenever { mockResponse.actionEdits }.thenReturn(Optional.of(mockEdits))
+
+        val result = underTest.save(course)
+
+        assertAll(
+            { verify(mockCourse).fetch(course.courseId) },
+            {
+                verify(mockEditCourse)
+                    .apply(any<dev.dragonejt.hakase_sdk.actions.EditCourseActionRequest>())
+            },
+            { assertThat(result).isEqualTo(course) },
+        )
+    }
+
+    @Test
+    @DisplayName("CourseRepository finds course by ID")
+    fun testFindById() {
+        val courseId = "test_course_id"
+
+        val mockObjects = mock<OntologyBaseObjectSets>()
+        whenever { ontology.objects() }.thenReturn(mockObjects)
+
+        val mockCourse = mock<CourseObjectSet>()
+        whenever { mockObjects.Course() }.thenReturn(mockCourse)
+
+        val mockOsdkCourse = mock<dev.dragonejt.hakase_sdk.objects.Course>()
+        whenever { mockOsdkCourse.courseId() }.thenReturn(Optional.of(courseId))
+        whenever { mockOsdkCourse.notifyChannel() }.thenReturn(Optional.of("channel_id"))
+        whenever { mockOsdkCourse.notifyGroup() }.thenReturn(Optional.of("group_id"))
+
+        whenever { mockCourse.fetch(courseId) }.thenReturn(Optional.of(mockOsdkCourse))
+
+        val result = underTest.findById(courseId)
+
+        assertAll(
+            { verify(mockCourse).fetch(courseId) },
+            { assertThat(result).isPresent() },
+            { assertThat(result.get().courseId).isEqualTo(courseId) },
+            { assertThat(result.get().notifyChannel).isEqualTo("channel_id") },
+            { assertThat(result.get().notifyGroup).isEqualTo("group_id") },
+        )
+    }
+
+    @Test
+    @DisplayName("CourseRepository deletes course by ID")
+    fun testDeleteById() {
+        val courseId = "test_course_id"
+
+        val mockActions = mock<OntologyActions>()
+        whenever { ontology.actions() }.thenReturn(mockActions)
+
+        val mockDeleteCourse = mock<dev.dragonejt.hakase_sdk.actions.DeleteCourseAction>()
+        whenever { mockActions.deleteCourse() }.thenReturn(mockDeleteCourse)
+
+        val mockResponse =
+            org.mockito.Mockito.mock(
+                dev.dragonejt.hakase_sdk.actions.DeleteCourseActionResponse::class.java,
+                org.mockito.Mockito.RETURNS_DEEP_STUBS,
+            )
+        whenever {
+                mockDeleteCourse.apply(
+                    any<dev.dragonejt.hakase_sdk.actions.DeleteCourseActionRequest>()
+                )
+            }
+            .thenReturn(mockResponse)
+
+        whenever { mockResponse.validationResult.validation.result }
+            .thenReturn(com.palantir.osdk.api.actions.ValidationResult.VALID)
+        val mockEdits = mock<dev.dragonejt.hakase_sdk.actions.DeleteCourseActionEditsResult>()
+        whenever { mockResponse.actionEdits }.thenReturn(Optional.of(mockEdits))
+
+        underTest.deleteById(courseId)
+
+        verify(mockDeleteCourse)
+            .apply(any<dev.dragonejt.hakase_sdk.actions.DeleteCourseActionRequest>())
+    }
+}


### PR DESCRIPTION
Added the ability to add, update, and delete courses from the CourseRepository.
Courses are now automatically added and deleted from the CourseRepository upon joining or leaving a Guild.